### PR TITLE
fix: Do first try immediately, then activate floor

### DIFF
--- a/retrier.go
+++ b/retrier.go
@@ -15,7 +15,7 @@ type Retrier struct {
 // New creates a retrier that exponentially backs off from floor to ceil pauses.
 func New(floor, ceil time.Duration) *Retrier {
 	return &Retrier{
-		delay: floor,
+		delay: 0,
 		floor: floor,
 		ceil:  ceil,
 	}
@@ -29,6 +29,9 @@ func (r *Retrier) Wait(ctx context.Context) bool {
 	}
 	select {
 	case <-time.After(r.delay):
+		if r.delay < r.floor {
+			r.delay = r.floor
+		}
 		return true
 	case <-ctx.Done():
 		return false

--- a/retrier_test.go
+++ b/retrier_test.go
@@ -15,3 +15,17 @@ func TestContextCancel(t *testing.T) {
 		t.Fatalf("attempt allowed even though context cancelled")
 	}
 }
+
+func TestFirstTryImmediately(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := New(time.Hour, time.Hour)
+	tt := time.Now()
+	if !r.Wait(ctx) {
+		t.Fatalf("attempt not allowed")
+	}
+	if time.Since(tt) > time.Second {
+		t.Fatalf("attempt took too long")
+	}
+}


### PR DESCRIPTION
I noticed retries were always taking `floor` to activate (https://github.com/coder/coder/blob/af59e2bcfa524dd0f93a186b69a8e43d2a31702e/agent/agent.go#L189), and then realized that floor isn't really even used here. So I assumed this was a bug and changed it so that first try is done immediately.
